### PR TITLE
Content filter

### DIFF
--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -82,7 +82,6 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 					$image_meta = wp_get_attachment_metadata( $attachment_id );
 					$image_str = wp_image_add_srcset_and_sizes( $image, $image_meta, $attachment_id );
 
-					$source = '<source>';
 					$webp_meta = get_post_meta( $attachment_id, '_wp_webp_metadata', true );
 					$webp_str = WPIS_Filters::wpis_source_add_srcset_and_sizes( $image, $webp_meta, $attachment_id );
 

--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 		 * @return string The filtered content
 		 */
 		public static function wpis_make_content_images_responsive( $content ) {
-			preg_match_all( '/<img[\s]*(?:class="[\w\s]*?wp-image-\d+[\w\s]*?)[^<]*\/?>(?!<noscript>|<\/noscript>)/is', $content, $matches );
+			preg_match_all( '/<img[^<]*(?:wp-image-\d+)[^<]*\/?>(?!<noscript>|<\/noscript>)/is', $content, $matches );
 
 			$selected_images = [];
 			$attachment_ids = [];

--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 		 * @return string The filtered content
 		 */
 		public static function wpis_make_content_images_responsive( $content ) {
-			preg_match_all( '/<img.*(:?class="(?:[\s\w\d-]+)?wp-image-\d+(?:[\s\w\d-]+)?")[^<]*\/?>(?!<noscript>|<\/noscript>)/is', $content, $matches );
+			preg_match_all( '/<img[\s]*(?:class="[\w\s]*?wp-image-\d+[\w\s]*?)[^<]*\/?>(?!<noscript>|<\/noscript>)/is', $content, $matches );
 
 			$selected_images = [];
 			$attachment_ids = [];

--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -83,6 +83,7 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 						continue;
 					}
 
+
 					$image_meta = wp_get_attachment_metadata( $attachment_id );
 					$image_str = wp_image_add_srcset_and_sizes( $image, $image_meta, $attachment_id );
 

--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -35,5 +35,56 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 				$util->delete_attachment();
 			}
 		}
+
+		/**
+		 * Custom function for making responsive images
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @param string $content The content
+		 * @return string The filtered content
+		 */
+		public static function wpis_get_attachment_image_srcset( $content ) {
+			preg_match_all( '/<img[\s]*[^<]*>(?!<noscript>|<\/noscript>)/is', $content, $matches );
+
+			$selected_images = [];
+			$attachment_ids = [];
+
+			if ( count( $matches[0] ) ) {
+				foreach( $matches[0] as $image ) {
+					$escaped = preg_replace( '/([\\\^$.[\]|()?*+{}\/~-])/', '\\\\$0', $image );
+					if ( preg_match( '~<picture[^>]*>(?:[\s]*<[\s]*[^<]*\/?>[\s]*)*(?:' . $escaped . ')(?:[\s]*<[\s]*[^<]*\/?>[\s]*)*[\s]*<\/picture>~', $content, $res ) ) {
+						continue;
+					}
+
+					if ( false === strpos( $image, ' srcset=' ) && preg_match( '/wp-image-([0-9]+)/i', $image, $class_id ) ) {
+						$attachment_id = absint( $class_id[1] );
+						if ( $attachment_id ) {
+							/*
+							 * If exactly the same image tag is used more than once, overwrite it.
+							 * All identical tags will be replaced later with 'str_replace()'.
+							 */
+							$selected_images[ $image ] = $attachment_id;
+							// Overwrite the ID when the same image is included more than once.
+							$attachment_ids[ $attachment_id ] = true;
+						}
+					}
+				}
+
+				if ( count( $attachment_ids ) > 1 ) {
+					/*
+					 * Warm the object cache with post and meta information for all found
+					 * images to avoid making individual database calls.
+					 */
+					_prime_post_caches( array_keys( $attachment_ids ), false, true );
+				}
+
+				foreach ( $selected_images as $image => $attachment_id ) {
+					$image_meta = wp_get_attachment_metadata( $attachment_id );
+					$content    = str_replace( $image, wp_image_add_srcset_and_sizes( $image, $image_meta, $attachment_id ), $content );
+				}
+			}
+
+			return $content;
+		}
 	}
 }

--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 		 * @return string The filtered content
 		 */
 		public static function wpis_make_content_images_responsive( $content ) {
-			preg_match_all( '/<img[\s]*[^<]*>/is', $content, $matches );
+			preg_match_all( '/<img[\s]*[^<]*\/?>(?!<noscript>|<\/noscript>)/is', $content, $matches );
 
 			$selected_images = [];
 			$attachment_ids = [];
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 						continue;
 					}
 
-					if ( false === strpos( $image, ' srcset=' ) && preg_match( '/wp-image-([0-9]+)/i', $image, $class_id ) ) {
+					if ( false === strpos( $image, 'srcset=' ) && preg_match( '/wp-image-([0-9]+)/i', $image, $class_id ) ) {
 						$attachment_id = absint( $class_id[1] );
 						if ( $attachment_id ) {
 							/*

--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 		 * @return string The filtered content
 		 */
 		public static function wpis_make_content_images_responsive( $content ) {
-			preg_match_all( '/<img[\s]*(?:class="[\w\s]*?wp-image-\d+[\w\s]*?)[^<]*\/?>(?!<noscript>|<\/noscript>)/is', $content, $matches );
+			preg_match_all( '/<img.*(:?class="(?:[\s\w\d-]+)?wp-image-\d+(?:[\s\w\d-]+)?")[^<]*\/?>(?!<noscript>|<\/noscript>)/is', $content, $matches );
 
 			$selected_images = [];
 			$attachment_ids = [];

--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -79,6 +79,9 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 				}
 
 				foreach ( $selected_images as $image => $attachment_id ) {
+					if ( ! wp_attachment_is_image( $attachment_id ) ) {
+						continue;
+					}
 
 					$image_meta = wp_get_attachment_metadata( $attachment_id );
 					$image_str = wp_image_add_srcset_and_sizes( $image, $image_meta, $attachment_id );

--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 		 * @return string The filtered content
 		 */
 		public static function wpis_make_content_images_responsive( $content ) {
-			preg_match_all( '/<img[\s]*[^<]*\/?>(?!<noscript>|<\/noscript>)/is', $content, $matches );
+			preg_match_all( '/<img[\s]*(?:class="[\w\s]*?wp-image-\d+[\w\s]*?)[^<]*\/?>(?!<noscript>|<\/noscript>)/is', $content, $matches );
 
 			$selected_images = [];
 			$attachment_ids = [];
@@ -79,6 +79,7 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 				}
 
 				foreach ( $selected_images as $image => $attachment_id ) {
+
 					$image_meta = wp_get_attachment_metadata( $attachment_id );
 					$image_str = wp_image_add_srcset_and_sizes( $image, $image_meta, $attachment_id );
 
@@ -91,7 +92,7 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 						$full_string = '<picture>' . $webp_str . $full_string . '</picture>';
 					}
 
-					$content    = str_replace( $image, $full_string, $content );
+					$content = str_replace( $image, $full_string, $content );
 				}
 			}
 

--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -44,7 +44,7 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 		 * @return string The filtered content
 		 */
 		public static function wpis_make_content_images_responsive( $content ) {
-			preg_match_all( '/<img[\s]*[^<]*>(?!<noscript>|<\/noscript>)/is', $content, $matches );
+			preg_match_all( '/<img[\s]*[^<]*>/is', $content, $matches );
 
 			$selected_images = [];
 			$attachment_ids = [];

--- a/includes/class-filters.php
+++ b/includes/class-filters.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'WPIS_Filters' ) ) {
 		 * @param string $content The content
 		 * @return string The filtered content
 		 */
-		public static function wpis_get_attachment_image_srcset( $content ) {
+		public static function wpis_make_content_images_responsive( $content ) {
 			preg_match_all( '/<img[\s]*[^<]*>(?!<noscript>|<\/noscript>)/is', $content, $matches );
 
 			$selected_images = [];

--- a/wp-image-sources.php
+++ b/wp-image-sources.php
@@ -46,8 +46,8 @@ if ( ! function_exists( 'wpis_init' ) ) {
 		add_filter( 'wp_generate_attachment_metadata', array( 'WPIS_Filters', 'wpis_generate_attachment_metadata' ), 10, 2 );
 		add_filter( 'delete_attachment', array( 'WPIS_Filters', 'wpis_delete_attachment' ), 10, 1 );
 
-		remove_filter( 'the_content', 'wp_get_attachment_image_srcset' );
-		add_filter( 'the_content', array( 'WPIS_Filters', 'wpis_get_attachment_image_srcset' ), 10, 1 );
+		remove_filter( 'the_content', 'wp_make_content_images_responsive' );
+		add_filter( 'the_content', array( 'WPIS_Filters', 'wpis_make_content_images_responsive' ), 10, 1 );
 	}
 
 	add_action( 'plugins_loaded', 'wpis_init' );

--- a/wp-image-sources.php
+++ b/wp-image-sources.php
@@ -45,6 +45,9 @@ if ( ! function_exists( 'wpis_init' ) ) {
 	function wpis_init() {
 		add_filter( 'wp_generate_attachment_metadata', array( 'WPIS_Filters', 'wpis_generate_attachment_metadata' ), 10, 2 );
 		add_filter( 'delete_attachment', array( 'WPIS_Filters', 'wpis_delete_attachment' ), 10, 1 );
+
+		remove_filter( 'the_content', 'wp_get_attachment_image_srcset' );
+		add_filter( 'the_content', array( 'WPIS_Filters', 'wpis_get_attachment_image_srcset' ), 10, 1 );
 	}
 
 	add_action( 'plugins_loaded', 'wpis_init' );

--- a/wp-image-sources.php
+++ b/wp-image-sources.php
@@ -47,7 +47,7 @@ if ( ! function_exists( 'wpis_init' ) ) {
 		add_filter( 'delete_attachment', array( 'WPIS_Filters', 'wpis_delete_attachment' ), 10, 1 );
 
 		remove_filter( 'the_content', 'wp_make_content_images_responsive' );
-		add_filter( 'the_content', array( 'WPIS_Filters', 'wpis_make_content_images_responsive' ), 10, 1 );
+		add_filter( 'the_content', array( 'WPIS_Filters', 'wpis_make_content_images_responsive' ), 99, 1 );
 	}
 
 	add_action( 'plugins_loaded', 'wpis_init' );


### PR DESCRIPTION
<!---
Thank you for contributing to wp-image-sources.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/wp-image-sources/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds the content filter that's used to insert the `<picture>` and `<source>` elements needed to serve up the webp images.

**Motivation and Context**
This allows the webp images that are created on upload or the manual conversion process to actually be served in the context.

**How Has This Been Tested?**
This is currently setup and running in DEV, and has been modified to work with the `lazysizes` plugin we're considering using. Currently, there is a problem when the "Add fallback for users without javascript" option is checked on the `lazysizes` plugin, and I will be continuing to try to make this plugin compatible with that setting. However, the code works fine with that plugin uninstalled or that option unchecked.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
